### PR TITLE
Add CombineCNN and streamline training script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,35 @@
-# VirtualStaining
+# Virtual Staining
+
+Dieses Beispielprojekt demonstriert, wie man mit Python mehrere
+neuronale Netze für unterschiedliche Färbungen aufbauen kann. Für jede
+Färbung wird ein eigenes Netz (``StainNet``) verwendet. Ein weiteres Netz
+(``CombineNet``) kombiniert die Vorhersagen der einzelnen Färbungen, um
+fluoreszierende Aufnahmen aus Brightfield-Bildern zu erzeugen.
+
+Die Datei ``train_cnn.py`` enthält die Definitionen der einzelnen
+Stain-Netze sowie einen kleinen Trainingsablauf. Das hierbei verwendete
+Kombinationsnetz ``CombineCNN`` wird in ``combine_cnn.py`` bereitgestellt.
+
+Zusätzlich steht ein kleines ``UNet`` in ``unet.py`` bereit, das als
+Basis für die Rekonstruktion einzelner Färbungen dient. Ein Beispiel ist
+``train_DAPI.py``, das DAPI-Aufnahmen aus Brightfield-Bildern generiert.
+Die Daten werden dabei über ``dataloader.py`` geladen, das zufällige
+256×256 Tiles aus 1024×1024 Bildern ausschneidet.
+
+Zum Starten des Beispieltrainings kann folgender Befehl verwendet
+werden:
+
+```bash
+python train_cnn.py
+```
+
+Zum Trainieren des DAPI-Modells benötigt man passende Bildordner mit
+Brightfield- und DAPI-Aufnahmen und ruft beispielsweise auf:
+
+```bash
+python train_DAPI.py --bf_dir /path/to/bf --dapi_dir /path/to/dapi --epochs 5
+```
+
+Die Trainingsroutinen verwenden Platzhalter- bzw. Zufallsdaten und dienen
+nur zur Illustration der Netzwerkstruktur. Für reale Anwendungen müssen
+passende Bilddatensätze und Verlustfunktionen eingebunden werden.

--- a/combine_cnn.py
+++ b/combine_cnn.py
@@ -1,0 +1,18 @@
+import torch
+import torch.nn as nn
+
+class CombineCNN(nn.Module):
+    """Simple convolutional network with three layers for combining stain predictions."""
+
+    def __init__(self, in_channels: int, out_channels: int = 3):
+        super().__init__()
+        self.model = nn.Sequential(
+            nn.Conv2d(in_channels, 16, kernel_size=3, padding=1),
+            nn.ReLU(inplace=True),
+            nn.Conv2d(16, 16, kernel_size=3, padding=1),
+            nn.ReLU(inplace=True),
+            nn.Conv2d(16, out_channels, kernel_size=3, padding=1),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.model(x)

--- a/dataloader.py
+++ b/dataloader.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+"""Dataset and DataLoader utilities for DAPI training."""
+
+from __future__ import annotations
+
+import os
+import random
+from typing import List
+
+from PIL import Image
+import numpy as np
+import torch
+from torch.utils.data import DataLoader, Dataset
+
+
+class BFDAPIDataset(Dataset):
+    """Loads matching brightfield and DAPI images and returns random tiles."""
+
+    def __init__(self, bf_dir: str, dapi_dir: str, tile_size: int = 256):
+        self.bf_paths: List[str] = sorted(
+            [
+                os.path.join(bf_dir, f)
+                for f in os.listdir(bf_dir)
+                if f.lower().endswith((".png", ".jpg", ".jpeg", ".tif", ".tiff"))
+            ]
+        )
+        self.dapi_dir = dapi_dir
+        self.tile_size = tile_size
+
+    def __len__(self) -> int:
+        return len(self.bf_paths)
+
+    def _load_image(self, path: str, mode: str = "RGB") -> np.ndarray:
+        img = Image.open(path).convert(mode)
+        return np.array(img)
+
+    def __getitem__(self, idx: int):
+        bf_path = self.bf_paths[idx]
+        filename = os.path.basename(bf_path)
+        dapi_path = os.path.join(self.dapi_dir, filename)
+
+        bf = self._load_image(bf_path, mode="RGB")
+        dapi = self._load_image(dapi_path, mode="L")
+
+        h, w = bf.shape[:2]
+        if h < self.tile_size or w < self.tile_size:
+            raise ValueError("Input images are smaller than the tile size")
+
+        x = random.randint(0, w - self.tile_size)
+        y = random.randint(0, h - self.tile_size)
+
+        bf_tile = bf[y : y + self.tile_size, x : x + self.tile_size]
+        dapi_tile = dapi[y : y + self.tile_size, x : x + self.tile_size]
+
+        bf_tensor = torch.from_numpy(bf_tile.transpose(2, 0, 1)).float() / 255.0
+        dapi_tensor = torch.from_numpy(dapi_tile).unsqueeze(0).float() / 255.0
+
+        return bf_tensor, dapi_tensor
+
+
+def create_dataloader(
+    bf_dir: str,
+    dapi_dir: str,
+    batch_size: int = 4,
+    tile_size: int = 256,
+    shuffle: bool = True,
+) -> DataLoader:
+    dataset = BFDAPIDataset(bf_dir, dapi_dir, tile_size=tile_size)
+    return DataLoader(dataset, batch_size=batch_size, shuffle=shuffle)

--- a/train_DAPI.py
+++ b/train_DAPI.py
@@ -1,0 +1,49 @@
+"""Training script for reconstructing DAPI from brightfield images using UNet."""
+
+from __future__ import annotations
+
+import argparse
+
+import torch
+import torch.nn as nn
+from torch.utils.data import DataLoader
+
+from dataloader import create_dataloader
+from unet import UNet
+
+
+def train_epoch(dataloader: DataLoader, model: UNet, loss_fn: nn.Module, optimizer: torch.optim.Optimizer, device: torch.device) -> None:
+    model.train()
+    for bf, dapi in dataloader:
+        bf = bf.to(device)
+        dapi = dapi.to(device)
+        pred = model(bf)
+        loss = loss_fn(pred, dapi)
+        optimizer.zero_grad()
+        loss.backward()
+        optimizer.step()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Train UNet to predict DAPI from brightfield images")
+    parser.add_argument("--bf_dir", required=True, help="Directory with brightfield images (1024x1024)")
+    parser.add_argument("--dapi_dir", required=True, help="Directory with corresponding DAPI images")
+    parser.add_argument("--epochs", type=int, default=1)
+    parser.add_argument("--batch_size", type=int, default=4)
+    args = parser.parse_args()
+
+    dataloader = create_dataloader(args.bf_dir, args.dapi_dir, batch_size=args.batch_size)
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model = UNet().to(device)
+    optimizer = torch.optim.Adam(model.parameters(), lr=1e-3)
+    loss_fn = nn.MSELoss()
+
+    for _ in range(args.epochs):
+        train_epoch(dataloader, model, loss_fn, optimizer, device)
+
+    print("DAPI training finished")
+
+
+if __name__ == "__main__":
+    main()

--- a/train_cnn.py
+++ b/train_cnn.py
@@ -1,0 +1,116 @@
+# -*- coding: utf-8 -*-
+"""Network definitions for virtual staining.
+
+This module contains PyTorch implementations for per-stain networks and
+for a network that combines multiple stains into a final fluorescence
+prediction.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+
+
+class StainNet(nn.Module):
+    """Simple convolutional network for a single stain."""
+
+    def __init__(self, in_channels: int = 3, out_channels: int = 1):
+        super().__init__()
+        self.model = nn.Sequential(
+            nn.Conv2d(in_channels, 16, kernel_size=3, padding=1),
+            nn.ReLU(inplace=True),
+            nn.Conv2d(16, 16, kernel_size=3, padding=1),
+            nn.ReLU(inplace=True),
+            nn.Conv2d(16, out_channels, kernel_size=3, padding=1),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.model(x)
+
+
+class CombineNet(nn.Module):
+    """Network that combines predictions from multiple stain networks."""
+
+    def __init__(self, num_stains: int, out_channels: int = 3):
+        super().__init__()
+        self.model = nn.Sequential(
+            nn.Conv2d(num_stains, 32, kernel_size=3, padding=1),
+            nn.ReLU(inplace=True),
+            nn.Conv2d(32, 32, kernel_size=3, padding=1),
+            nn.ReLU(inplace=True),
+            nn.Conv2d(32, out_channels, kernel_size=3, padding=1),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.model(x)
+
+
+class DummyDataset(torch.utils.data.Dataset):
+    """Simple dataset returning random brightfield and stain tensors."""
+
+    def __init__(self, num_samples: int = 10, image_shape: tuple[int, int] = (64, 64)):
+        super().__init__()
+        self.num_samples = num_samples
+        self.image_shape = image_shape
+
+    def __len__(self) -> int:
+        return self.num_samples
+
+    def __getitem__(self, idx: int):
+        brightfield = torch.randn(3, *self.image_shape)
+        stains = {
+            "stain1": torch.randn(1, *self.image_shape),
+            "stain2": torch.randn(1, *self.image_shape),
+        }
+        return brightfield, stains
+
+
+def train_epoch(
+    dataloader: torch.utils.data.DataLoader,
+    stain_nets: dict[str, StainNet],
+    combine_net: nn.Module,
+    loss_fn: nn.Module,
+    optimizer: torch.optim.Optimizer,
+) -> None:
+    for brightfield, stains in dataloader:
+        preds = []
+        for name, net in stain_nets.items():
+            pred = net(brightfield)
+            loss = loss_fn(pred, stains[name])
+            loss.backward()
+            preds.append(pred)
+        stacked = torch.cat(preds, dim=1)
+        combined = combine_net(stacked)
+        combined_loss = combined.abs().mean()
+        combined_loss.backward()
+        optimizer.step()
+        optimizer.zero_grad()
+
+
+def main() -> None:
+    from combine_cnn import CombineCNN
+
+    dataset = DummyDataset()
+    dataloader = torch.utils.data.DataLoader(dataset, batch_size=2)
+
+    stain_nets = {
+        "stain1": StainNet(),
+        "stain2": StainNet(),
+    }
+    combine_net = CombineCNN(in_channels=len(stain_nets), out_channels=3)
+
+    params = list(combine_net.parameters())
+    for net in stain_nets.values():
+        params += list(net.parameters())
+
+    optimizer = torch.optim.Adam(params, lr=1e-3)
+    loss_fn = nn.MSELoss()
+
+    for _ in range(2):
+        train_epoch(dataloader, stain_nets, combine_net, loss_fn, optimizer)
+    print("training finished")
+
+
+if __name__ == "__main__":
+    main()

--- a/unet.py
+++ b/unet.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+"""Small UNet architecture with residual blocks.
+
+This network serves as a base model for reconstructing individual stains
+such as DAPI from brightfield images.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+
+
+class ResidualBlock(nn.Module):
+    """Classic residual block with two convolutions."""
+
+    def __init__(self, channels: int):
+        super().__init__()
+        self.conv1 = nn.Conv2d(channels, channels, kernel_size=3, padding=1)
+        self.relu = nn.ReLU(inplace=True)
+        self.conv2 = nn.Conv2d(channels, channels, kernel_size=3, padding=1)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        residual = x
+        out = self.conv1(x)
+        out = self.relu(out)
+        out = self.conv2(out)
+        out += residual
+        return self.relu(out)
+
+
+class UNet(nn.Module):
+    """UNet with three levels and skip connections."""
+
+    def __init__(self, in_channels: int = 3, out_channels: int = 1, base_feat: int = 32):
+        super().__init__()
+        self.down1 = nn.Sequential(
+            nn.Conv2d(in_channels, base_feat, kernel_size=3, padding=1),
+            ResidualBlock(base_feat),
+        )
+        self.pool1 = nn.MaxPool2d(2)
+
+        self.down2 = nn.Sequential(
+            nn.Conv2d(base_feat, base_feat * 2, kernel_size=3, padding=1),
+            ResidualBlock(base_feat * 2),
+        )
+        self.pool2 = nn.MaxPool2d(2)
+
+        self.bottleneck = nn.Sequential(
+            nn.Conv2d(base_feat * 2, base_feat * 4, kernel_size=3, padding=1),
+            ResidualBlock(base_feat * 4),
+        )
+
+        self.up2 = nn.ConvTranspose2d(base_feat * 4, base_feat * 2, kernel_size=2, stride=2)
+        self.up_block2 = nn.Sequential(
+            nn.Conv2d(base_feat * 4, base_feat * 2, kernel_size=3, padding=1),
+            ResidualBlock(base_feat * 2),
+        )
+
+        self.up1 = nn.ConvTranspose2d(base_feat * 2, base_feat, kernel_size=2, stride=2)
+        self.up_block1 = nn.Sequential(
+            nn.Conv2d(base_feat * 2, base_feat, kernel_size=3, padding=1),
+            ResidualBlock(base_feat),
+        )
+
+        self.final_conv = nn.Conv2d(base_feat, out_channels, kernel_size=1)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        d1 = self.down1(x)
+        p1 = self.pool1(d1)
+        d2 = self.down2(p1)
+        p2 = self.pool2(d2)
+        b = self.bottleneck(p2)
+        u2 = self.up2(b)
+        u2 = torch.cat([u2, d2], dim=1)
+        u2 = self.up_block2(u2)
+        u1 = self.up1(u2)
+        u1 = torch.cat([u1, d1], dim=1)
+        u1 = self.up_block1(u1)
+        return self.final_conv(u1)


### PR DESCRIPTION
## Summary
- remove `train_virtual_staining.py`
- rename `stain_networks.py` to `train_cnn.py`
- add `combine_cnn.py` with a simple three-layer network
- integrate a small training loop in `train_cnn.py`
- update README for the new file names

## Testing
- `python -m py_compile train_cnn.py train_DAPI.py dataloader.py unet.py combine_cnn.py`
- `python train_cnn.py` *(fails: ModuleNotFoundError: No module named 'torch')*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_684bcc6e3f248323853742900d612171