### PR TITLE
Simplify dataloader, training and evaluation scripts

### DIFF
--- a/Data_handling/dataloader.py
+++ b/Data_handling/dataloader.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Dataset and DataLoader utilities for DAPI training."""
+"""Dataset utilities for training a DAPI reconstruction network."""
 
 import os
 import random
@@ -8,74 +8,56 @@ from torch.utils.data import Dataset
 import torchvision.transforms.functional as TF
 
 class BFDAPIDataset(Dataset):
-    """
-    Liefert 256×256-Tiles aus BF und DAPI (Graustufen).
-    Wendet Rotation (Vielfache von 90°), Flip und ColorJitter an.
-    Rückgabe: (bf_tensor, dapi_tensor)
-    """
+    """Yields random 256×256 tiles from brightfield and DAPI images."""
+
     def __init__(
-            self,
-            bf_dir: str,
-            dapi_dir: str,
-            file_list: list,
-            tile_size: int = 256,
-            num_tiles_per_image: int = 100,
-            transform=None
-    ):
+        self,
+        bf_dir: str,
+        dapi_dir: str,
+        file_list: list[str],
+        tile_size: int = 256,
+        tiles_per_image: int = 100,
+    ) -> None:
         self.bf_dir = bf_dir
         self.dapi_dir = dapi_dir
         self.file_list = file_list
         self.tile_size = tile_size
-        self.num_tiles_per_image = num_tiles_per_image
-        self.n = len(file_list) * num_tiles_per_image
+        self.tiles_per_image = tiles_per_image
+        self.n = len(file_list) * tiles_per_image
 
     def __len__(self) -> int:
         return self.n
 
     def __getitem__(self, idx: int):
-      # 1) Bestimme Bild und Datei
-      image_idx = idx // self.num_tiles_per_image
-      fname = self.file_list[image_idx]
+        fname = self.file_list[idx // self.tiles_per_image]
+        bf = Image.open(os.path.join(self.bf_dir, fname)).convert("L")
+        dapi = Image.open(os.path.join(self.dapi_dir, fname)).convert("L")
 
-      # 2) Lade beide Kanäle als Graustufen
-      bf = Image.open(os.path.join(self.bf_dir, fname)).convert("L")
-      dapi = Image.open(os.path.join(self.dapi_dir, fname)).convert("L")
+        w, h = bf.size
+        x0 = random.randint(0, w - self.tile_size)
+        y0 = random.randint(0, h - self.tile_size)
+        box = (x0, y0, x0 + self.tile_size, y0 + self.tile_size)
+        bf = bf.crop(box)
+        dapi = dapi.crop(box)
 
-      # 3) Identischer Crop
-      w, h = bf.size
-      x0 = random.randint(0, w - self.tile_size)
-      y0 = random.randint(0, h - self.tile_size)
-      crop_bf = bf.crop((x0, y0, x0 + self.tile_size, y0 + self.tile_size))
-      crop_dapi = dapi.crop((x0, y0, x0 + self.tile_size, y0 + self.tile_size))
+        angle = random.choice([0, 90, 180, 270])
+        bf = bf.rotate(angle)
+        dapi = dapi.rotate(angle)
+        if random.random() < 0.5:
+            bf = ImageOps.mirror(bf)
+            dapi = ImageOps.mirror(dapi)
+        if random.random() < 0.5:
+            bf = ImageOps.flip(bf)
+            dapi = ImageOps.flip(dapi)
 
-      # 4) Gemeinsame Rotation um Vielfache von 90°
-      angle = random.choice([0, 90, 180, 270])
-      crop_bf = crop_bf.rotate(angle)
-      crop_dapi = crop_dapi.rotate(angle)
+        b = random.uniform(0.9, 1.1)
+        c = random.uniform(0.9, 1.1)
+        bf = TF.adjust_contrast(TF.adjust_brightness(bf, b), c)
+        dapi = TF.adjust_contrast(TF.adjust_brightness(dapi, b), c)
 
-      # 5) Gemeinsames horizontales Flip?
-      if random.random() < 0.5:
-        crop_bf = ImageOps.mirror(crop_bf)
-        crop_dapi = ImageOps.mirror(crop_dapi)
+        bf = TF.to_tensor(bf)
+        bf = TF.normalize(bf, [0.5], [0.5])
+        dapi = TF.to_tensor(dapi)
+        dapi = TF.normalize(dapi, [0.5], [0.5])
 
-      # 6) Gemeinsames vertikales Flip?
-      if random.random() < 0.5:
-        crop_bf = ImageOps.flip(crop_bf)
-        crop_dapi = ImageOps.flip(crop_dapi)
-
-      # 7) Gemeinsames ColorJitter (Helligkeit & Kontrast)
-      b_factor = random.uniform(0.9, 1.1)
-      c_factor = random.uniform(0.9, 1.1)
-      crop_bf = TF.adjust_brightness(crop_bf, b_factor)
-      crop_dapi = TF.adjust_brightness(crop_dapi, b_factor)
-      crop_bf = TF.adjust_contrast(crop_bf, c_factor)
-      crop_dapi = TF.adjust_contrast(crop_dapi, c_factor)
-
-      # 8) ToTensor & Normalize
-      # bf_tensor = TF.to_tensor(crop_bf)
-      # bf_tensor = TF.normalize(bf_tensor, [0.5], [0.5])
-      # dapi_tensor = TF.to_tensor(crop_dapi)
-      # dapi_tensor = TF.normalize(dapi_tensor, [0.5], [0.5])
-
-      #return bf_tensor, dapi_tensor
-      return crop_bf, crop_dapi
+        return bf, dapi

--- a/Training_files/train_DAPI.py
+++ b/Training_files/train_DAPI.py
@@ -1,6 +1,4 @@
-"""Training script for reconstructing DAPI from brightfield images using UNet."""
-
-from __future__ import annotations
+"""Train UNet to reconstruct DAPI images from brightfield inputs."""
 
 import argparse
 import os
@@ -11,66 +9,49 @@ from torch.utils.data import DataLoader
 from Data_handling.dataloader import BFDAPIDataset
 from Models.unet import UNet
 
-BF_DIR       = "Data_handling/Trainings_Daten/8_bit/BF"
-DAPI_DIR     = "Data_handling/Trainings_Daten/8_bit/DAPI"
-FILE_LIST   = [f for f in os.listdir(BF_DIR) if f.lower().endswith(".tif")]
-N_EPOCHS    = 20
-DEVICE      = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
-def get_loaders(batch_size):
-    # Split in Train/Val
-    split = int(0.8 * len(FILE_LIST))
-    train_files, val_files = FILE_LIST[:split], FILE_LIST[split:]
-
-    train_ds = BFDAPIDataset(
-        bf_dir=BF_DIR,
-        dapi_dir=DAPI_DIR,
-        file_list=train_files,
-        tile_size=256,
-        num_tiles_per_image=100
-    )
-    val_ds = BFDAPIDataset(
-        bf_dir=BF_DIR,
-        dapi_dir=DAPI_DIR,
-        file_list=val_files,
-        tile_size=256,
-        num_tiles_per_image=100
-    )
-    train_loader = DataLoader(train_ds, batch_size=batch_size, shuffle=True, num_workers=4)
-    val_loader   = DataLoader(val_ds,   batch_size=batch_size, shuffle=False, num_workers=4)
-    return train_loader, val_loader
+def get_loaders(bf_dir: str, dapi_dir: str, batch_size: int):
+    files = [f for f in os.listdir(bf_dir) if f.lower().endswith(".tif")]
+    split = int(0.8 * len(files))
+    train_ds = BFDAPIDataset(bf_dir, dapi_dir, files[:split])
+    val_ds = BFDAPIDataset(bf_dir, dapi_dir, files[split:])
+    kwargs = dict(batch_size=batch_size, num_workers=4, shuffle=True)
+    return DataLoader(train_ds, **kwargs), DataLoader(val_ds, **kwargs)
 
 
-def train_epoch(dataloader: DataLoader, model: UNet, loss_fn: nn.Module, optimizer: torch.optim.Optimizer, device: torch.device) -> None:
+def train_epoch(loader: DataLoader, model: UNet, loss_fn: nn.Module,
+                optimizer: torch.optim.Optimizer, device: torch.device) -> None:
     model.train()
-    for bf, dapi in dataloader:
-        bf = bf.to(device)
-        dapi = dapi.to(device)
-        pred = model(bf)
-        loss = loss_fn(pred, dapi)
+    for bf, dapi in loader:
+        bf, dapi = bf.to(device), dapi.to(device)
+        loss = loss_fn(model(bf), dapi)
         optimizer.zero_grad()
         loss.backward()
         optimizer.step()
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Train UNet to predict DAPI from brightfield images")
-    parser.add_argument("--bf_dir", required=True, help="Directory with brightfield images (1024x1024)")
-    parser.add_argument("--dapi_dir", required=True, help="Directory with corresponding DAPI images")
+    parser = argparse.ArgumentParser(
+        description="Train UNet for DAPI reconstruction")
+    parser.add_argument("--bf_dir", required=True)
+    parser.add_argument("--dapi_dir", required=True)
     parser.add_argument("--epochs", type=int, default=1)
     parser.add_argument("--batch_size", type=int, default=4)
+    parser.add_argument("--out", default="dapi_model.pth",
+                        help="Path to save model weights")
     args = parser.parse_args()
 
-    dataloader = BFDAPIDataset(args.bf_dir, args.dapi_dir, batch_size=args.batch_size)
+    train_loader, _ = get_loaders(args.bf_dir, args.dapi_dir, args.batch_size)
 
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    model = UNet().to(device)
+    model = UNet(in_channels=1, out_channels=1).to(device)
     optimizer = torch.optim.Adam(model.parameters(), lr=1e-3)
     loss_fn = nn.MSELoss()
 
     for _ in range(args.epochs):
-        train_epoch(dataloader, model, loss_fn, optimizer, device)
+        train_epoch(train_loader, model, loss_fn, optimizer, device)
 
+    torch.save(model.state_dict(), args.out)
     print("DAPI training finished")
 
 

--- a/eval.py
+++ b/eval.py
@@ -1,0 +1,34 @@
+"""Apply a trained DAPI model to a single brightfield image."""
+
+import argparse
+import torch
+from PIL import Image
+import torchvision.transforms.functional as TF
+from Models.unet import UNet
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Predict DAPI staining for a brightfield image")
+    parser.add_argument("--model", required=True, help="Path to model weights")
+    parser.add_argument("--input", required=True, help="Brightfield image file")
+    parser.add_argument("--output", required=True, help="Where to save the DAPI prediction")
+    args = parser.parse_args()
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model = UNet(in_channels=1, out_channels=1).to(device)
+    model.load_state_dict(torch.load(args.model, map_location=device))
+    model.eval()
+
+    img = Image.open(args.input).convert("L")
+    tensor = TF.normalize(TF.to_tensor(img), [0.5], [0.5]).unsqueeze(0).to(device)
+
+    with torch.no_grad():
+        pred = model(tensor).squeeze(0).cpu()
+
+    out = pred * 0.5 + 0.5
+    TF.to_pil_image(out).save(args.output)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- streamline dataset implementation
- simplify training script for DAPI UNet
- rewrite eval script with minimal code

## Testing
- `python -m py_compile Data_handling/dataloader.py Training_files/train_DAPI.py eval.py`

------
https://chatgpt.com/codex/tasks/task_e_684c2b716e5c83239d52e10b6a9df3f8